### PR TITLE
Put command values in same order as on cards

### DIFF
--- a/flagship/src/app/fleets/ship-detail/ship-detail.component.html
+++ b/flagship/src/app/fleets/ship-detail/ship-detail.component.html
@@ -19,8 +19,8 @@
     <mat-card-subtitle>
       Hull: {{ ship.hull }}
       | Command: {{ ship.command }}
+      | Squadron: {{ ship.squadron }}
       | Engineering: {{ ship.engineering }}
-      | Squadron {{ ship.squadron }}
 
     </mat-card-subtitle>
   </mat-card-header>


### PR DESCRIPTION
Now the command values read left-to-right the same way they read top-to-bottom on the actual ship cards :) I also added a missing ':'