### PR TITLE
Properly serialize all battle state

### DIFF
--- a/flagship/src/app/campaign/battle-phase/battle-phase.component.ts
+++ b/flagship/src/app/campaign/battle-phase/battle-phase.component.ts
@@ -101,6 +101,7 @@ export class BattlePhaseComponent implements OnInit, OnChanges {
     this.completeButtonOptions.active = true;
     this.removeSpentTokens(this.empireTokens, this.campaign.empire);
     this.removeSpentTokens(this.rebelTokens, this.campaign.rebels);
+    let currentState = this.campaign.currentState();
     
     for (let i = 0; i < this.battles.length; i++) {
       let battle = this.battles[i];
@@ -129,8 +130,10 @@ export class BattlePhaseComponent implements OnInit, OnChanges {
         this.applyFleetMods(fleet);
         this.fleetService.updateFleet(fleet).then(() => { }, (errors) => { alert(errors); });
       }
+      currentState.updateBattle(battle);
     }
-    this.campaign.currentState().setPhase(Phase.Management);
+    
+    currentState.setPhase(Phase.Management);
     this.campaignService.updateCampaign(this.campaign).then(() => {
       this.phaseComplete.emit();
     }, (errors) => {

--- a/flagship/src/app/domain/campaign/campaignState.ts
+++ b/flagship/src/app/domain/campaign/campaignState.ts
@@ -58,6 +58,14 @@ export class CampaignState {
             .map(x => x as Battle);
     }
 
+    public updateBattle(battle: Battle) {
+        let battleToUpdate = this.getBattles().find(x => x.locationId === battle.locationId);
+        battleToUpdate.attackerResult = battle.attackerResult;
+        battleToUpdate.defenderResult = battle.defenderResult;
+        battleToUpdate.objectiveId = battle.objectiveId;
+        battleToUpdate.state = battle.state;
+    }
+
     public serialize(): SerializedCampaignState {
         return {
             turn: this.turn,


### PR DESCRIPTION
I've run into issues with the battle state not being properly serialized. When this happens, I get an error in the console stating "Cannot read property 'fleetPoints' of null". The battle state in the event history is incomplete when this happens, with the attackerResult, defenderResult, objectiveId being null, and the state staying at 0.