### PR TITLE
Adding ability to change campaign point total

### DIFF
--- a/flagship/src/app/campaign/campaign-info/campaign-info.component.html
+++ b/flagship/src/app/campaign/campaign-info/campaign-info.component.html
@@ -51,5 +51,8 @@
         <button mat-button (click)="setActScore()" color="accent">
             Set Score for Current Act
         </button>
+        <button mat-button (click)="setCampaignScore()" color="accent">
+            Set Score for Campaign
+        </button>
     </mat-card-actions>
 </mat-card>

--- a/flagship/src/app/campaign/campaign-info/campaign-info.component.ts
+++ b/flagship/src/app/campaign/campaign-info/campaign-info.component.ts
@@ -25,11 +25,11 @@ export class CampaignInfoComponent implements OnInit, OnChanges {
   user: firebase.User;
 
   constructor(private dialog: MatDialog, private campaignService: CampaignService,
-    private afAuth: AngularFireAuth) { 
-      this.afAuth.user.subscribe((user) => {
-        this.user = user;
-      })
-    }
+    private afAuth: AngularFireAuth) {
+    this.afAuth.user.subscribe((user) => {
+      this.user = user;
+    })
+  }
 
   ngOnInit() {
     this.setup();
@@ -63,7 +63,7 @@ export class CampaignInfoComponent implements OnInit, OnChanges {
           `Imperial Point Score Change from ${this.currentState.imperialPointsScored} to ${data.empireScore}.`,
           this.user.uid, new Date()));
         this.currentState.imperialPointsScored = data.empireScore;
-        
+
       }
       if (this.currentState.rebelPointsScored !== data.rebelScore) {
         let difference = this.currentState.rebelPointsScored - data.rebelScore;
@@ -80,6 +80,35 @@ export class CampaignInfoComponent implements OnInit, OnChanges {
         currentState.imperialPointsScored += winningFaction === Faction.Empire ? winningResult.earnedPoints : losingResult.earnedPoints;
         currentState.rebelPointsScored += winningFaction === Faction.Empire ? losingResult.earnedPoints : winningResult.earnedPoints;
 */
+    });
+  }
+
+  setCampaignScore() {
+    let ref = this.dialog.open(SetCampaignPointsDialogComponent, {
+      data: new SetCampaignPointsDialogData(null, this.campaign.empire.campaignPoints, this.campaign.rebels.campaignPoints),
+      maxWidth: '350px'
+    });
+    ref.afterClosed().subscribe((data: SetCampaignPointsDialogData) => {
+      if (!data) return;
+
+      if (this.campaign.empire.campaignPoints !== data.empireScore) {
+        this.currentState.addEvent(new CampaignEvent(
+          CampaignEventType.ManualScoreChange,
+          `Imperial Campaign Point Score Change from ${this.campaign.empire.campaignPoints} to ${data.empireScore}.`,
+          this.user.uid,
+          new Date()));
+        this.campaign.empire.campaignPoints = data.empireScore;
+      }
+
+      if (this.campaign.rebels.campaignPoints !== data.rebelScore) {
+        this.currentState.addEvent(new CampaignEvent(
+          CampaignEventType.ManualScoreChange,
+          `Rebel Campaign Point Score Change from ${this.currentState.rebelPointsScored} to ${data.rebelScore}.`,
+          this.user.uid,
+          new Date()));
+        this.campaign.rebels.campaignPoints = data.rebelScore;
+      }
+      this.campaignService.updateCampaign(this.campaign).then();
     });
   }
 }

--- a/flagship/src/app/campaign/set-campaign-points-dialog/set-campaign-points-dialog.component.html
+++ b/flagship/src/app/campaign/set-campaign-points-dialog/set-campaign-points-dialog.component.html
@@ -1,5 +1,6 @@
 <div mat-dialog-content>
-    <h3>Set Campaign Score for Act {{ data.act | numerals }}</h3>
+    <h3 *ngIf="isForCampaign">Set Campaign Score</h3>
+    <h3 *ngIf="!isForCampaign">Set Campaign Score for Act {{ data.act | numerals }}</h3>
     <p>
         You can manually set the score for the current act below.
         Note that Flagship will automatically record campaign points earned as
@@ -9,12 +10,12 @@
     </p>
     <form fxLayout="column">
         <mat-form-field>
-            <input placeholder="Empire Score"
-                matInput type="number" [(ngModel)]="empireScore" required min="0" name="empireScore"/>
+            <input placeholder="Empire Score" matInput type="number" [(ngModel)]="empireScore" required min="0"
+                name="empireScore" />
         </mat-form-field>
         <mat-form-field>
-            <input placeholder="Rebel Score"
-                matInput type="number" [(ngModel)]="rebelScore" required min="0" name="rebelScore"/>
+            <input placeholder="Rebel Score" matInput type="number" [(ngModel)]="rebelScore" required min="0"
+                name="rebelScore" />
         </mat-form-field>
     </form>
 </div>
@@ -22,6 +23,8 @@
     <button mat-button (click)="cancel()">Cancel</button>
     <span fxFlex></span>
     <button mat-button (click)="setScore()"
-        [disabled]="empireScore === null || empireScore < 0 || rebelScore === null || rebelScore < 0"
-        color="primary">Update Score for Current Act</button>
+        [disabled]="empireScore === null || empireScore < 0 || rebelScore === null || rebelScore < 0" color="primary">
+        <span *ngIf="isForCampaign">Update Score for Campaign</span>
+        <span *ngIf="!isForCampaign">Update Score for Current Act</span>
+    </button>
 </div>

--- a/flagship/src/app/campaign/set-campaign-points-dialog/set-campaign-points-dialog.component.ts
+++ b/flagship/src/app/campaign/set-campaign-points-dialog/set-campaign-points-dialog.component.ts
@@ -5,9 +5,7 @@ export class SetCampaignPointsDialogData {
   constructor(public act: number,
     public empireScore: number,
     public rebelScore: number) {
-
-    }
-
+  }
 }
 
 @Component({
@@ -16,26 +14,26 @@ export class SetCampaignPointsDialogData {
   styleUrls: ['./set-campaign-points-dialog.component.scss']
 })
 export class SetCampaignPointsDialogComponent implements OnInit {
-
+  public isForCampaign = false;
   public empireScore = null;
   public rebelScore = null;
 
   constructor(public dialogRef: MatDialogRef<SetCampaignPointsDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: SetCampaignPointsDialogData) { 
-    }
+    @Inject(MAT_DIALOG_DATA) public data: SetCampaignPointsDialogData) {
+  }
 
   ngOnInit() {
     this.rebelScore = this.data.rebelScore;
     this.empireScore = this.data.empireScore;
+    this.isForCampaign = this.data.act === null;
   }
 
   cancel() {
     this.dialogRef.close(null);
   }
-  
+
   setScore() {
     this.dialogRef.close(new SetCampaignPointsDialogData(this.data.act,
       this.empireScore, this.rebelScore));
   }
-
 }


### PR DESCRIPTION
https://github.com/videege/flagship/issues/57 is 2 bugs in one, but I'll probably close it after this PR because I don't feel like believing that I made an input mistake an hour past my usual bed time after a long day of work and a long night of Armada. :P 

My campaign's overall campaign points are totally wrong at this point, because of the possible input bug and because someone made an assault mistake we tried to cover up poorly. This feature would help us correct mistakes, and is inline with the existing feature to set the current acts point total.

I re-used the existing `set-campaign-points-dialog` and made it show slightly different text if there's no `act` provided on construction. 